### PR TITLE
Add preliminary work item link / attachment support

### DIFF
--- a/CSharp/TfsCmdlets.Common/Cmdlets/CmdletBase.cs
+++ b/CSharp/TfsCmdlets.Common/Cmdlets/CmdletBase.cs
@@ -232,7 +232,7 @@ namespace TfsCmdlets.Cmdlets
         /// <summary>
         /// Gets the current directory in PowerShell
         /// </summary>
-        protected virtual string ResolvePath(string basePath, string path = null)
+        protected virtual string ResolvePath(string basePath, string path = "")
         {
             var relativePath = Path.Combine(basePath, path);
 
@@ -343,6 +343,21 @@ namespace TfsCmdlets.Cmdlets
                     $"{attr.Version}{(attr.Update > 0 ? " Update" + attr.Update : "")} or later.{Environment.NewLine}");
             }
         }
+
+        private bool yesToAll, noToAll;
+
+        /// <inheritdoc/>
+        protected bool ShouldContinue(string query, string caption = "Confirm", bool hasSecurityImpact = false)
+        {
+            return ShouldContinue(query, caption, hasSecurityImpact, ref yesToAll, ref noToAll);
+        }
+
+        /// <inheritdoc/>
+        protected bool ShouldContinue(string query, ref bool yesToAll, ref bool noToAll, string caption = "Confirm", bool hasSecurityImpact = false)
+        {
+            return ShouldContinue(query, caption, hasSecurityImpact, ref yesToAll, ref noToAll);
+        }
+
 
         /// <summary>
         /// Performs execution of the command. Must be overriden in derived classes.

--- a/CSharp/TfsCmdlets.Common/Cmdlets/WorkItem/Linking/ExportWorkItemAttachment.cs
+++ b/CSharp/TfsCmdlets.Common/Cmdlets/WorkItem/Linking/ExportWorkItemAttachment.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using WebApiWorkItem = Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem;
+using TfsCmdlets.Extensions;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using TfsCmdlets.Util;
+using System.IO;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace TfsCmdlets.Cmdlets.WorkItem.Linking
+{
+    [Cmdlet(VerbsData.Export, "TfsWorkItemAttachment", SupportsShouldProcess = true)]
+    public class ExportWorkItemAttachment: CmdletBase
+    {
+        /// <summary>
+        /// Specifies the attachment to download. Wildcards are supported. 
+        /// When omitted, all attachments in the specified work item are exported.
+        /// </summary>
+        [Parameter(Position = 0)]
+        [ValidateNotNull()]
+        public object Attachment { get; set; } = "*";
+
+        /// <summary>
+        /// HELP_PARAM_WORKITEM
+        /// </summary>
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipeline = true)]
+        [ValidateNotNull()]
+        public object WorkItem { get; set; }
+
+        /// <summary>
+        /// Specifies the directory to save the attachment to. When omitted, defaults to the current directory.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNull()]
+        public string Destination { get; set; }
+
+        /// <summary>
+        /// Allows the cmdlet to overwrite an existing file.
+        /// </summary>
+        [Parameter()]
+        public SwitchParameter Force { get; set; }
+
+        /// <summary>
+        /// HELP_PARAM_COLLECTION
+        /// </summary>
+        [Parameter()]
+        public object Collection { get; set; }
+
+        /// <summary>
+        /// Performs execution of the command
+        /// </summary>
+        protected override void DoProcessRecord()
+        {
+            var wi = GetItem<WebApiWorkItem>(new
+            {
+                this.WorkItem,
+                IncludeLinks = true
+            });
+
+            string attachment;
+
+            switch (Attachment)
+            {
+                case WorkItemRelation r:
+                    {
+                        attachment = (string) r.Attributes["name"];
+                        break;
+                    }
+                case string s when !string.IsNullOrEmpty(s):
+                    {
+                        attachment = s;
+                        break;
+                    }
+                default:
+                    {
+                        throw new ArgumentException($"Invalid attachment '{Attachment}'");
+                    }
+            }
+
+            var (_, tp) = GetCollectionAndProject();
+            var client = GetClient<WorkItemTrackingHttpClient>();
+            var outputDir = ResolvePath(Destination);
+
+            Log($"Downloading attachments to output directory '{outputDir}'");
+
+            if(!Directory.Exists(outputDir))
+            {
+                if(!Force && !ShouldContinue($"Do you want to create destination directory '{outputDir}'?"))
+                {
+                    throw new ArgumentException("Destination path invalid or non-existent");
+                }
+
+                Directory.CreateDirectory(outputDir);
+            }
+
+            foreach (var att in wi.Relations.Where(l => l.Rel == "AttachedFile" && ((string)l.Attributes["name"]).IsLike(attachment)))
+            {
+                var name = ((string)att.Attributes["name"]);
+                var outputPath = Path.Combine(outputDir, name);
+                var exists = File.Exists(outputPath);
+
+                if (!ShouldProcess(name, $"Download attachment{(exists? " and overwrite existing file": "")}")) continue;
+
+                var uri = new Uri(att.Url);
+                var id = Guid.Parse(uri.Segments[uri.Segments.Length-1]);
+                
+                var stream = client.GetAttachmentContentAsync(id, name).SyncResult<Stream>();
+
+                if (exists && !Force && !ShouldContinue($"Are you sure you want to overwrite existing file '{outputPath}'?")) continue;
+
+                using var writer = new FileStream(outputPath, FileMode.Create);
+
+                stream.CopyTo(writer);
+            }
+        }
+    }
+}

--- a/CSharp/TfsCmdlets.PSCore/Properties/launchSettings.json
+++ b/CSharp/TfsCmdlets.PSCore/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "PowerShell Core": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\PowerShell\\7-preview\\pwsh.exe",
+      "executablePath": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
       "commandLineArgs": "-noexit -command \"Import-Module $(TargetPath)\""
     }
   }


### PR DESCRIPTION
## New cmdlets

- **Export-TfsWorkItemAttachment**: Downloads the file contents of work item attachments.

## Migrated cmdlets

-  **Get-TfsWorkItemLink**: To get links and attachment metadata from work items. 

## Updated cmdlets

- **Get-TfsWorkItem**: New switch `-IncludeLinks` to fetch link/attachment information