### PR TITLE
Add SuppressNotifications support (2.7.0)

### DIFF
--- a/CSharp/TfsCmdlets/Cmdlets/WorkItem/NewWorkItem.cs
+++ b/CSharp/TfsCmdlets/Cmdlets/WorkItem/NewWorkItem.cs
@@ -120,5 +120,11 @@ namespace TfsCmdlets.Cmdlets.WorkItem
         /// </summary>
         [Parameter]
         public SwitchParameter BypassRules { get; set; }
+
+        /// <summary>
+        /// Do not fire any notifications for this change. Useful for bulk operations and automated processes.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter SuppressNotifications { get; set; }
     }
 }

--- a/CSharp/TfsCmdlets/Cmdlets/WorkItem/SetWorkItem.cs
+++ b/CSharp/TfsCmdlets/Cmdlets/WorkItem/SetWorkItem.cs
@@ -131,5 +131,11 @@ namespace TfsCmdlets.Cmdlets.WorkItem
         /// </summary>
         [Parameter]
         public SwitchParameter BypassRules { get; set; }
+
+        /// <summary>
+        /// Do not fire any notifications for this change. Useful for bulk operations and automated processes.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter SuppressNotifications { get; set; }
     }
 }

--- a/CSharp/TfsCmdlets/Controllers/WorkItem/NewWorkItemController.cs
+++ b/CSharp/TfsCmdlets/Controllers/WorkItem/NewWorkItemController.cs
@@ -22,7 +22,7 @@ namespace TfsCmdlets.Controllers.WorkItem
 
             var client = Data.GetClient<WorkItemTrackingHttpClient>();
 
-            var result = client.CreateWorkItemAsync(Builder.GetJson(wi), Project.Name, type.Name, false, BypassRules)
+            var result = client.CreateWorkItemAsync(Builder.GetJson(wi), Project.Name, type.Name, false, BypassRules, SuppressNotifications)
                 .GetResult("Error creating work item");
 
             yield return result;

--- a/CSharp/TfsCmdlets/Controllers/WorkItem/SetWorkItemController.cs
+++ b/CSharp/TfsCmdlets/Controllers/WorkItem/SetWorkItemController.cs
@@ -19,7 +19,7 @@ namespace TfsCmdlets.Controllers.WorkItem
 
             foreach (var wi in Items)
             {
-                var result = client.UpdateWorkItemAsync(Builder.GetJson(wi), (int)wi.Id, false, BypassRules)
+                var result = client.UpdateWorkItemAsync(Builder.GetJson(wi), (int)wi.Id, false, BypassRules, SuppressNotifications)
                     .GetResult("Error updating work item");
 
                 yield return result;

--- a/Docs/ReleaseNotes/2.7.0.md
+++ b/Docs/ReleaseNotes/2.7.0.md
@@ -1,6 +1,6 @@
 # TfsCmdlets Release Notes
 
-## Version 2.7.0 (_15/May/2024_)
+## Version 2.7.0 (_03/Jul/2024_)
 
 This release adds support for suppressing notifications when creating or updating work items.
 

--- a/Docs/ReleaseNotes/2.7.0.md
+++ b/Docs/ReleaseNotes/2.7.0.md
@@ -1,0 +1,9 @@
+# TfsCmdlets Release Notes
+
+## Version 2.7.0 (_15/May/2024_)
+
+This release adds support for suppressing notifications when creating or updating work items.
+
+## New features
+
+* Adds `-SuppressNotifications` switch to `New-TfsWorkItem` and `Set-TfsWorkItem` to suppress notifications when creating or updating work items. This is useful when you are creating or updating a large number of work items and don't want to flood the notification feed of team members.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,22 +1,20 @@
 # TfsCmdlets Release Notes
 
-## Version 2.6.1 (_15/May/2024_)
+## Version 2.7.0 (_15/May/2024_)
 
-Ouch! It's been a while since the last release! Sometimes life gets in the way, but I'm back!
+This release adds support for suppressing notifications when creating or updating work items.
 
-This release fixes bugs in `Get-TfsWorkItem`, `Get-TfsArea`, `Get-TfsIteration`, `Invoke-TfsRestApi`, `New-TfsTeam` and `Set-TfsTeam`.
+## New features
 
-## Fixes
-
-* Fixes [#211](https://github.com/igoravl/TfsCmdlets/issues/211), where `Get-TfsWorkItem` would throw an error when the `-Fields` parameter was "*".
-* Fixes a bug in `Invoke-TfsRestApi` where Azure DevOps APIs whose responses were missing the `content-type` header would throw an error.
-* Fixes a bug in `Get-TfsArea` and `Get-TfsIteration` where team projects containing Regex-reserved characters (such as parentheses) would throw an error. This bug would indirectly affect `New-TfsTeam` and `Set-TfsTeam` due to their reliance on the same underlying class to handle area and iteration paths when creating/updating teams.
-* Fixes a bug in `Get-TfsWorkItem` where the `-AreaPath` and `-IterationPath` parameters would not work when the specified path either started with a backslash or did not contain the team project name.
-* Adds the installed module version to the _Azure DevOps Shell_ startup command to prevent loading an older version of the module when the PSModulePath variable contains an older version of the module listed earlier in the search path.
+* Adds `-SuppressNotifications` switch to `New-TfsWorkItem` and `Set-TfsWorkItem` to suppress notifications when creating or updating work items. This is useful when you are creating or updating a large number of work items and don't want to flood the notification feed of team members.
 
 -----------------------
 
 ## Previous Versions
+
+### Version 2.6.1 (_15/May/2024_)
+
+See release notes [here](Docs/ReleaseNotes/2.6.1.md).
 
 ### Version 2.6.0 (_30/Sep/2022_)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 # TfsCmdlets Release Notes
 
-## Version 2.7.0 (_15/May/2024_)
+## Version 2.7.0 (_03/Jul/2024_)
 
 This release adds support for suppressing notifications when creating or updating work items.
 


### PR DESCRIPTION
## Version 2.7.0 (_03/Jul/2024_)

This release adds support for suppressing notifications when creating or updating work items.

## New features

* Adds `-SuppressNotifications` switch to `New-TfsWorkItem` and `Set-TfsWorkItem` to suppress notifications when creating or updating work items. This is useful when you are creating or updating a large number of work items and don't want to flood the notification feed of team members.
